### PR TITLE
feat: dynamodb locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_dynamodb_table.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |

--- a/main.tf
+++ b/main.tf
@@ -33,3 +33,18 @@ resource "aws_s3_bucket_versioning" "this" {
     status = "Enabled"
   }
 }
+
+resource "aws_dynamodb_table" "this" {
+  name         = var.bucket_name
+  hash_key     = "LockID"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name = var.bucket_name
+  }
+}


### PR DESCRIPTION
## Related Tasks

In prep for franklin.ai

## Depends on

N/A

## What

Adds the missing dynamodb terraform state locking table

## Why

This was omitted from the initial configuration

## Concerns

None

## Notes

We'll need to remember to update all state buckets with this change

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
