### PR TITLE
13 ACL's to be conditional for new buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.1.2
+
+- Make the `aws_s3_bucket_acl` resource conditional depending on the Object Ownership value, to fall into line with the new rules regarding [S3 bucket creation](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/)
+
 ## v0.1.1
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,8 @@ resource "aws_s3_bucket" "this" {
 }
 
 resource "aws_s3_bucket_acl" "this" {
+  count = var.object_ownership == "BucketOwnerEnforced" ? 0 : 1
+
   bucket = aws_s3_bucket.this.id
   acl    = "private"
 }


### PR DESCRIPTION
## What

Make the `aws_s3_bucket_acl` resource conditional depending on the Object Ownership value, to fall into line with the new rules regarding [S3 bucket creation](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/)
